### PR TITLE
feat: add optional Mux workspace integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ Thumbs.db
 # Test outputs
 /tmp/
 .history/
+
+# Mux local instruction override (optional)
+.mux/AGENTS.local.md

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # THE CLAUDE PROTOCOL
 
-**Enforcement-first orchestration for Claude Code. Every agent tracked. Every decision logged. Nothing gets lost.**
+**Enforcement-first orchestration for Claude Code, with optional Mux workspace integration. Every agent tracked. Every decision logged. Nothing gets lost.**
 
 **Claude Code plans great. Without structure, nothing survives past one session.**
 
@@ -83,6 +83,17 @@ Every task goes through beads — unless the user explicitly approves a quick fi
 
 The Claude Protocol pairs with the [Beads Kanban UI](https://github.com/AvivK5498/Beads-Kanban-UI) for visual task management and GitOps directly from the browser. Track epics, subtasks, dependencies, and PR status across columns — without leaving the board.
 
+### Mux Integration (Optional)
+
+You can also bootstrap **Mux-compatible workspace files** to align with Mux's instruction and hook model:
+
+- `.mux/AGENTS.md` (workspace instruction layer)
+- `.mux/init` (runs `bd prime --stealth`)
+- `.mux/tool_post` (syncs beads after edits)
+- `.mux/tool_env` (ensures `~/bin` is on `PATH` for bash tool calls)
+
+These files match the concepts documented in `https://mux.coder.com/` (instruction files + init/tool hooks) while keeping beads as the source of truth for task tracking.
+
 ---
 
 ## Getting Started
@@ -102,6 +113,8 @@ Then in any Claude Code session:
 ```bash
 /create-beads-orchestration
 ```
+
+For Mux-oriented projects, pass `--with-mux` in the bootstrap command prompted by the skill (or run `beads-orchestration bootstrap --with-mux`) to install `.mux/*` workspace files.
 
 The skill walks you through setup, scans your tech stack, and creates supervisors with best practices injected.
 
@@ -154,6 +167,13 @@ CLAUDE.md             # Orchestrator instructions
 .beads/               # Task database
   memory/             # Knowledge base (knowledge.jsonl + recall.sh)
 .worktrees/           # Isolated worktrees per task (created dynamically)
+
+# Optional with --with-mux
+.mux/
+├── AGENTS.md         # Mux workspace instruction layer
+├── init              # Workspace init hook (bd prime --stealth)
+├── tool_post         # Post-tool hook (bd sync on file edits)
+└── tool_env          # Bash env hook (adds ~/bin to PATH)
 ```
 
 ---
@@ -173,6 +193,16 @@ CLAUDE.md             # Orchestrator instructions
 **UserPromptSubmit** (1 hook) — Prompt for clarification on ambiguous requests.
 
 ---
+
+## Advanced: Mux Workspace Mode
+
+Use bootstrap with Mux files:
+
+```bash
+beads-orchestration bootstrap --project-dir . --with-mux
+```
+
+This installs `.mux/AGENTS.md`, `.mux/init`, `.mux/tool_post`, and `.mux/tool_env` in addition to the standard Claude/beads setup.
 
 ## Advanced: External Providers
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Then in any Claude Code session:
 /create-beads-orchestration
 ```
 
-For Mux-oriented projects, pass `--with-mux` in the bootstrap command prompted by the skill (or run `beads-orchestration bootstrap --with-mux`) to install `.mux/*` workspace files.
+For Mux-oriented projects, pass `--with-mux` in the bootstrap command prompted by the skill (or run `beads-orchestration bootstrap --with-mux`) to use **Mux-only mode** (`.mux/*` + `.beads`, no `.claude/*`).
 
 The skill walks you through setup, scans your tech stack, and creates supervisors with best practices injected.
 
@@ -168,7 +168,7 @@ CLAUDE.md             # Orchestrator instructions
   memory/             # Knowledge base (knowledge.jsonl + recall.sh)
 .worktrees/           # Isolated worktrees per task (created dynamically)
 
-# Optional with --with-mux
+# With --with-mux (Mux-only mode)
 .mux/
 ├── AGENTS.md         # Mux workspace instruction layer
 ├── init              # Workspace init hook (bd prime --stealth)
@@ -202,7 +202,7 @@ Use bootstrap with Mux files:
 beads-orchestration bootstrap --project-dir . --with-mux
 ```
 
-This installs `.mux/AGENTS.md`, `.mux/init`, `.mux/tool_post`, and `.mux/tool_env` in addition to the standard Claude/beads setup.
+This installs only Mux + beads files (`.mux/*` and `.beads`) and intentionally skips all `.claude/*` installation.
 
 ## Advanced: External Providers
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: create-beads-orchestration
-description: Bootstrap lean multi-agent orchestration with beads task tracking. Use for projects needing agent delegation without heavy MCP overhead.
+description: Bootstrap lean multi-agent orchestration with beads task tracking. Includes optional Mux workspace integration.
 user-invocable: true
+advertise: true
 ---
 
 # Create Beads Orchestration
@@ -83,6 +84,17 @@ Ask the user or auto-detect from package.json/pyproject.toml.
 which bead-kanban 2>/dev/null && echo "KANBAN_FOUND" || echo "KANBAN_NOT_FOUND"
 ```
 
+### 1.3 Detect Mux usage (optional but recommended)
+
+Check whether the project already uses Mux workspace files:
+
+```bash
+ls .mux/AGENTS.md .mux/init .mux/tool_post .mux/tool_env >/dev/null 2>&1 && echo "MUX_FOUND" || echo "MUX_NOT_FOUND"
+```
+
+- If `MUX_FOUND` → Use `--with-mux` in bootstrap command.
+- If `MUX_NOT_FOUND` → Ask user if they want Mux compatibility. If yes, use `--with-mux`.
+
 **If KANBAN_FOUND** → Use `--with-kanban-ui` flag. Tell the user:
 > Detected Beads Kanban UI. Configuring worktree management via API.
 
@@ -118,10 +130,23 @@ npx beads-orchestration@latest bootstrap \
   --project-dir "{{PROJECT_DIR}}" \
   --with-kanban-ui
 
+# With Kanban UI + Mux workspace files:
+npx beads-orchestration@latest bootstrap \
+  --project-name "{{PROJECT_NAME}}" \
+  --project-dir "{{PROJECT_DIR}}" \
+  --with-kanban-ui \
+  --with-mux
+
 # Without Kanban UI (git worktrees only):
 npx beads-orchestration@latest bootstrap \
   --project-name "{{PROJECT_NAME}}" \
   --project-dir "{{PROJECT_DIR}}"
+
+# Without Kanban UI + Mux workspace files:
+npx beads-orchestration@latest bootstrap \
+  --project-name "{{PROJECT_NAME}}" \
+  --project-dir "{{PROJECT_DIR}}" \
+  --with-mux
 ```
 
 The bootstrap script will:
@@ -132,6 +157,7 @@ The bootstrap script will:
 5. Configure `.claude/settings.json`
 6. Create `CLAUDE.md` with orchestrator instructions
 7. Update `.gitignore`
+8. (Optional) Install Mux workspace files (`.mux/AGENTS.md`, `.mux/init`, `.mux/tool_post`, `.mux/tool_env`)
 
 **Verify bootstrap completed successfully before proceeding.**
 
@@ -211,6 +237,11 @@ Discovery will:
 
 **Without `--with-kanban-ui`:**
 - Worktrees created via raw git commands
+
+**With `--with-mux`:**
+- Installs `.mux/AGENTS.md` instruction layer
+- Installs `.mux/init`, `.mux/tool_post`, `.mux/tool_env`
+- Runs `.mux/init` once after bootstrap (best-effort)
 
 ## Epic Workflow (Cross-Domain Features)
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -92,8 +92,8 @@ Check whether the project already uses Mux workspace files:
 ls .mux/AGENTS.md .mux/init .mux/tool_post .mux/tool_env >/dev/null 2>&1 && echo "MUX_FOUND" || echo "MUX_NOT_FOUND"
 ```
 
-- If `MUX_FOUND` → Use `--with-mux` in bootstrap command.
-- If `MUX_NOT_FOUND` → Ask user if they want Mux compatibility. If yes, use `--with-mux`.
+- If `MUX_FOUND` → Use `--with-mux` in bootstrap command (Mux-only mode).
+- If `MUX_NOT_FOUND` → Ask user if they want Mux-only compatibility. If yes, use `--with-mux`.
 
 **If KANBAN_FOUND** → Use `--with-kanban-ui` flag. Tell the user:
 > Detected Beads Kanban UI. Configuring worktree management via API.
@@ -152,12 +152,9 @@ npx beads-orchestration@latest bootstrap \
 The bootstrap script will:
 1. Install beads CLI (via brew, npm, or go)
 2. Initialize `.beads/` directory
-3. Copy agent templates to `.claude/agents/`
-4. Copy hooks to `.claude/hooks/`
-5. Configure `.claude/settings.json`
-6. Create `CLAUDE.md` with orchestrator instructions
-7. Update `.gitignore`
-8. (Optional) Install Mux workspace files (`.mux/AGENTS.md`, `.mux/init`, `.mux/tool_post`, `.mux/tool_env`)
+3. Update `.gitignore`
+4. If `--with-mux`: install Mux-only files (`.mux/AGENTS.md`, `.mux/init`, `.mux/tool_post`, `.mux/tool_env`) and skip `.claude/*`
+5. If not `--with-mux`: install full Claude orchestration (`.claude/agents`, `.claude/hooks`, `.claude/settings.json`, `CLAUDE.md`)
 
 **Verify bootstrap completed successfully before proceeding.**
 
@@ -238,10 +235,11 @@ Discovery will:
 **Without `--with-kanban-ui`:**
 - Worktrees created via raw git commands
 
-**With `--with-mux`:**
+**With `--with-mux` (Mux-only mode):**
 - Installs `.mux/AGENTS.md` instruction layer
 - Installs `.mux/init`, `.mux/tool_post`, `.mux/tool_env`
 - Runs `.mux/init` once after bootstrap (best-effort)
+- Skips all `.claude/*` and `CLAUDE.md`
 
 ## Epic Workflow (Cross-Domain Features)
 

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -10,7 +10,7 @@ Creates:
 - .mcp.json with provider-delegator configuration (only with --external-providers)
 
 Usage:
-    python bootstrap.py [--project-name NAME] [--project-dir DIR] [--with-kanban-ui]
+    python bootstrap.py [--project-name NAME] [--project-dir DIR] [--with-kanban-ui] [--with-mux]
 
 Modes:
     Default: All agents use Claude Task() directly (claude-only)
@@ -620,18 +620,72 @@ def copy_claude_md(project_dir: Path, project_name: str, claude_only: bool = Fal
 
 
 # ============================================================================
+# MUX WORKSPACE FILES
+# ============================================================================
+
+def copy_mux_workspace_files(project_dir: Path, project_name: str) -> None:
+    """Install Mux workspace integration files (.mux/init, .mux/tool_post, .mux/tool_env, .mux/AGENTS.md)."""
+    print("\n[MUX] Installing Mux workspace files...")
+
+    mux_template_dir = TEMPLATES_DIR / "mux"
+    mux_dir = project_dir / ".mux"
+    mux_dir.mkdir(parents=True, exist_ok=True)
+
+    # Copy instruction layer
+    agents_template = mux_template_dir / "AGENTS.md"
+    agents_dest = mux_dir / "AGENTS.md"
+    if agents_template.exists():
+        copy_and_replace(agents_template, agents_dest, {"[Project]": project_name})
+        print("  - Copied .mux/AGENTS.md")
+    else:
+        print("  - WARNING: Missing template templates/mux/AGENTS.md")
+
+    # Copy Mux hooks
+    init_src = mux_template_dir / "init"
+    init_dest = mux_dir / "init"
+    if init_src.exists():
+        shutil.copy2(init_src, init_dest)
+        init_dest.chmod(init_dest.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        print("  - Copied .mux/init")
+    else:
+        print("  - WARNING: Missing template templates/mux/init")
+
+    tool_post_src = mux_template_dir / "tool_post"
+    tool_post_dest = mux_dir / "tool_post"
+    if tool_post_src.exists():
+        shutil.copy2(tool_post_src, tool_post_dest)
+        tool_post_dest.chmod(tool_post_dest.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        print("  - Copied .mux/tool_post")
+    else:
+        print("  - WARNING: Missing template templates/mux/tool_post")
+
+    tool_env_src = mux_template_dir / "tool_env"
+    tool_env_dest = mux_dir / "tool_env"
+    if tool_env_src.exists():
+        shutil.copy2(tool_env_src, tool_env_dest)
+        tool_env_dest.chmod(0o644)
+        print("  - Copied .mux/tool_env")
+    else:
+        print("  - WARNING: Missing template templates/mux/tool_env")
+
+    print("  DONE: Mux workspace files installed")
+
+
+# ============================================================================
 # GITIGNORE
 # ============================================================================
 
-def setup_gitignore(project_dir: Path, claude_only: bool = False) -> None:
-    """Ensure .beads is in .gitignore. .claude/ is tracked (not ignored)."""
+def setup_gitignore(project_dir: Path, claude_only: bool = False, with_mux: bool = False) -> None:
+    """Ensure ephemeral files are in .gitignore. .claude/ and .mux/ are tracked."""
     step = "[7/7]" if claude_only else "[7/8]"
     print(f"\n{step} Setting up .gitignore...")
 
     gitignore_path = project_dir / ".gitignore"
-    # Only ignore .beads/ (ephemeral task data) and .mcp.json (user-specific paths)
-    # .claude/ is tracked so it survives git operations
+    # Ignore ephemeral task/runtime data and local instruction overrides.
+    # .claude/ and .mux/ are tracked so configuration survives git operations.
     entries_to_add = [".beads/", ".mcp.json"]
+    if with_mux:
+        entries_to_add.append(".mux/AGENTS.local.md")
 
     if gitignore_path.exists():
         content = gitignore_path.read_text()
@@ -651,12 +705,18 @@ def setup_gitignore(project_dir: Path, claude_only: bool = False) -> None:
                 # Add newline if file doesn't end with one
                 if content and not content.endswith("\n"):
                     f.write("\n")
-                f.write("\n# Beads task tracking (ephemeral)\n")
+                if with_mux:
+                    f.write("\n# Beads and local agent runtime state (ephemeral)\n")
+                else:
+                    f.write("\n# Beads task tracking (ephemeral)\n")
                 for entry in missing:
                     f.write(f"{entry}\n")
                     print(f"  - Added {entry} to .gitignore")
         else:
-            print("  - .beads/ and .mcp.json already in .gitignore")
+            if with_mux:
+                print("  - .beads/, .mcp.json, and .mux/AGENTS.local.md already in .gitignore")
+            else:
+                print("  - .beads/ and .mcp.json already in .gitignore")
     else:
         # Create new .gitignore
         content = """# Beads task tracking (ephemeral)
@@ -665,11 +725,26 @@ def setup_gitignore(project_dir: Path, claude_only: bool = False) -> None:
 # MCP config (user-specific paths)
 .mcp.json
 """
+        if with_mux:
+            content = """# Beads and local agent runtime state (ephemeral)
+.beads/
+.mux/AGENTS.local.md
+
+# MCP config (user-specific paths)
+.mcp.json
+"""
+
         gitignore_path.write_text(content)
-        print("  - Created .gitignore with .beads/ and .mcp.json")
+        if with_mux:
+            print("  - Created .gitignore with .beads/, .mcp.json, and .mux/AGENTS.local.md")
+        else:
+            print("  - Created .gitignore with .beads/ and .mcp.json")
 
     print("  DONE: .gitignore configured")
-    print("  NOTE: .claude/ is tracked (not ignored) to prevent accidental loss")
+    if with_mux:
+        print("  NOTE: .claude/ and .mux/ are tracked (not ignored) to prevent accidental loss")
+    else:
+        print("  NOTE: .claude/ is tracked (not ignored) to prevent accidental loss")
 
 
 # ============================================================================
@@ -720,7 +795,7 @@ def create_mcp_config(project_dir: Path, venv_python: Path) -> None:
 # VERIFICATION
 # ============================================================================
 
-def verify_installation(project_dir: Path, claude_only: bool = False) -> bool:
+def verify_installation(project_dir: Path, claude_only: bool = False, with_mux: bool = False) -> bool:
     """Verify all components were installed correctly."""
     checks = {
         ".claude/hooks": "Hooks directory",
@@ -730,6 +805,12 @@ def verify_installation(project_dir: Path, claude_only: bool = False) -> bool:
         "CLAUDE.md": "CLAUDE.md",
         ".gitignore": ".gitignore",
     }
+
+    if with_mux:
+        checks[".mux/AGENTS.md"] = "Mux workspace AGENTS.md"
+        checks[".mux/init"] = "Mux init hook"
+        checks[".mux/tool_post"] = "Mux tool_post hook"
+        checks[".mux/tool_env"] = "Mux tool_env hook"
 
     # Only check for .mcp.json in external providers mode
     if not claude_only:
@@ -780,11 +861,14 @@ def main():
                         help="Use Codex/Gemini for delegation (default: Claude-only)")
     parser.add_argument("--with-kanban-ui", action="store_true",
                         help="Use Beads Kanban UI API for worktree creation (with git fallback)")
+    parser.add_argument("--with-mux", action="store_true",
+                        help="Install Mux workspace files (.mux/AGENTS.md, .mux/init, .mux/tool_post, .mux/tool_env)")
     args = parser.parse_args()
 
     project_dir = Path(args.project_dir).resolve()
     claude_only = not args.external_providers  # Default is now claude-only
     with_kanban_ui = args.with_kanban_ui
+    with_mux = args.with_mux
 
     # Ensure project directory exists
     project_dir.mkdir(parents=True, exist_ok=True)
@@ -798,10 +882,12 @@ def main():
 
     mode_str = "CLAUDE-ONLY" if claude_only else "EXTERNAL PROVIDERS"
     worktree_str = "API + git fallback" if with_kanban_ui else "git only"
+    mux_str = "enabled" if with_mux else "disabled"
     print(f"\nBootstrapping beads orchestration for: {project_name}")
     print(f"Directory: {project_dir}")
     print(f"Mode: {mode_str}")
     print(f"Worktrees: {worktree_str}")
+    print(f"Mux workspace files: {mux_str}")
     print("=" * 60)
 
     # Verify templates exist
@@ -834,7 +920,9 @@ def main():
         copy_settings(project_dir, claude_only=False)
         copy_claude_md(project_dir, project_name, claude_only=False)
         setup_memory(project_dir)
-        setup_gitignore(project_dir, claude_only=False)
+        if with_mux:
+            copy_mux_workspace_files(project_dir, project_name)
+        setup_gitignore(project_dir, claude_only=False, with_mux=with_mux)
         create_mcp_config(project_dir, venv_python)
     else:
         # Claude-only mode: skip provider setup
@@ -854,11 +942,16 @@ def main():
         copy_settings(project_dir, claude_only=True)
         copy_claude_md(project_dir, project_name, claude_only=True)
         setup_memory(project_dir)
-        setup_gitignore(project_dir, claude_only=True)
+        if with_mux:
+            copy_mux_workspace_files(project_dir, project_name)
+        setup_gitignore(project_dir, claude_only=True, with_mux=with_mux)
 
     # Verify
-    if not verify_installation(project_dir, claude_only):
+    if not verify_installation(project_dir, claude_only, with_mux=with_mux):
         print("\nWARNING: Installation incomplete - check errors above")
+
+    # Optional Mux init hook execution (matches Mux init behavior for new workspaces)
+    run_mux_init_if_present(project_dir, with_mux)
 
     print("\n" + "=" * 60)
     print("BOOTSTRAP COMPLETE")
@@ -872,7 +965,10 @@ Next steps:
 
 1. Restart Claude Code to load new hooks and agents
 
-2. **REQUIRED: Run discovery to create supervisors**
+2. (Optional) If you enabled Mux integration, restart your Mux workspace session
+   so .mux/init/.mux/tool_post/.mux/tool_env and .mux/AGENTS.md are loaded.
+
+3. **REQUIRED: Run discovery to create supervisors**
    Discovery will scan your codebase and fetch specialist agents:
 
    Task(
@@ -880,10 +976,10 @@ Next steps:
        prompt="Detect tech stack and create supervisors for {project_name}"
    )
 
-3. Create your first bead:
+4. Create your first bead:
    bd create "First task"
 
-4. Dispatch work to supervisors:
+5. Dispatch work to supervisors:
    Task(subagent_type="<supervisor-name>", prompt="BEAD_ID: BD-001\\n\\nImplement...")
 
 NOTE: All agents (scout, detective, architect, etc.) run via Claude Task().
@@ -897,7 +993,10 @@ Next steps:
 
 1. Restart Claude Code to load new hooks and agents
 
-2. **REQUIRED: Run discovery to create supervisors**
+2. (Optional) If you enabled Mux integration, restart your Mux workspace session
+   so .mux/init/.mux/tool_post/.mux/tool_env and .mux/AGENTS.md are loaded.
+
+3. **REQUIRED: Run discovery to create supervisors**
    Discovery will scan your codebase and fetch specialist agents:
 
    Task(
@@ -911,10 +1010,10 @@ Next steps:
    - Inject beads workflow at the beginning of each agent
    - Write supervisors to .claude/agents/
 
-3. Create your first bead:
+4. Create your first bead:
    bd create "First task"
 
-4. Dispatch work to supervisors:
+5. Dispatch work to supervisors:
    Task(subagent_type="<supervisor-name>", prompt="BEAD_ID: BD-001\\n\\nImplement...")
 
 NOTE: Read-only agents (scout, detective, architect, scribe, code-reviewer)
@@ -923,6 +1022,41 @@ Supervisors are sourced from https://github.com/ayush-that/sub-agents.directory
 with beads workflow injected.
 """)
 
+
+
+
+def run_mux_init_if_present(project_dir: Path, enabled: bool) -> None:
+    """Run .mux/init after bootstrap when Mux integration is enabled."""
+    if not enabled:
+        return
+
+    mux_init = project_dir / ".mux" / "init"
+    if not mux_init.exists():
+        print("\n[MUX] Skipping .mux/init (not found)")
+        return
+
+    print("\n[MUX] Running .mux/init...")
+    result = subprocess.run(
+        [str(mux_init)],
+        cwd=project_dir,
+        capture_output=True,
+        text=True,
+    )
+
+    if result.returncode == 0:
+        print("  - .mux/init completed successfully")
+    else:
+        print(f"  - WARNING: .mux/init exited with code {result.returncode}")
+
+    if result.stdout:
+        print("  - stdout:")
+        for line in result.stdout.strip().splitlines():
+            print(f"    {line}")
+
+    if result.stderr:
+        print("  - stderr:")
+        for line in result.stderr.strip().splitlines():
+            print(f"    {line}")
 
 if __name__ == "__main__":
     main()

--- a/scripts/cli.js
+++ b/scripts/cli.js
@@ -24,7 +24,7 @@ Commands:
 
 Examples:
   beads-orchestration install
-  beads-orchestration bootstrap --project-dir /path/to/project --claude-only
+  beads-orchestration bootstrap --project-dir /path/to/project --with-mux
 
 After installing, use /create-beads-orchestration in Claude Code.
 `);

--- a/scripts/cli.js
+++ b/scripts/cli.js
@@ -24,7 +24,7 @@ Commands:
 
 Examples:
   beads-orchestration install
-  beads-orchestration bootstrap --project-dir /path/to/project --with-mux
+  beads-orchestration bootstrap --project-dir /path/to/project --with-mux   # mux-only (no .claude)
 
 After installing, use /create-beads-orchestration in Claude Code.
 `);

--- a/skills/create-beads-orchestration/SKILL.md
+++ b/skills/create-beads-orchestration/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: create-beads-orchestration
-description: Bootstrap lean multi-agent orchestration with beads task tracking. Use for projects needing agent delegation without heavy MCP overhead.
+description: Bootstrap lean multi-agent orchestration with beads task tracking. Includes optional Mux workspace integration.
 user-invocable: true
+advertise: true
 ---
 
 # Create Beads Orchestration
@@ -83,6 +84,17 @@ Ask the user or auto-detect from package.json/pyproject.toml.
 which bead-kanban 2>/dev/null && echo "KANBAN_FOUND" || echo "KANBAN_NOT_FOUND"
 ```
 
+### 1.3 Detect Mux usage (optional but recommended)
+
+Check whether the project already uses Mux workspace files:
+
+```bash
+ls .mux/AGENTS.md .mux/init .mux/tool_post .mux/tool_env >/dev/null 2>&1 && echo "MUX_FOUND" || echo "MUX_NOT_FOUND"
+```
+
+- If `MUX_FOUND` → Use `--with-mux` in bootstrap command.
+- If `MUX_NOT_FOUND` → Ask user if they want Mux compatibility. If yes, use `--with-mux`.
+
 **If KANBAN_FOUND** → Use `--with-kanban-ui` flag. Tell the user:
 > Detected Beads Kanban UI. Configuring worktree management via API.
 
@@ -118,10 +130,23 @@ npx beads-orchestration@latest bootstrap \
   --project-dir "{{PROJECT_DIR}}" \
   --with-kanban-ui
 
+# With Kanban UI + Mux workspace files:
+npx beads-orchestration@latest bootstrap \
+  --project-name "{{PROJECT_NAME}}" \
+  --project-dir "{{PROJECT_DIR}}" \
+  --with-kanban-ui \
+  --with-mux
+
 # Without Kanban UI (git worktrees only):
 npx beads-orchestration@latest bootstrap \
   --project-name "{{PROJECT_NAME}}" \
   --project-dir "{{PROJECT_DIR}}"
+
+# Without Kanban UI + Mux workspace files:
+npx beads-orchestration@latest bootstrap \
+  --project-name "{{PROJECT_NAME}}" \
+  --project-dir "{{PROJECT_DIR}}" \
+  --with-mux
 ```
 
 The bootstrap script will:
@@ -132,6 +157,7 @@ The bootstrap script will:
 5. Configure `.claude/settings.json`
 6. Create `CLAUDE.md` with orchestrator instructions
 7. Update `.gitignore`
+8. (Optional) Install Mux workspace files (`.mux/AGENTS.md`, `.mux/init`, `.mux/tool_post`, `.mux/tool_env`)
 
 **Verify bootstrap completed successfully before proceeding.**
 
@@ -211,6 +237,11 @@ Discovery will:
 
 **Without `--with-kanban-ui`:**
 - Worktrees created via raw git commands
+
+**With `--with-mux`:**
+- Installs `.mux/AGENTS.md` instruction layer
+- Installs `.mux/init`, `.mux/tool_post`, `.mux/tool_env`
+- Runs `.mux/init` once after bootstrap (best-effort)
 
 ## Epic Workflow (Cross-Domain Features)
 

--- a/skills/create-beads-orchestration/SKILL.md
+++ b/skills/create-beads-orchestration/SKILL.md
@@ -92,8 +92,8 @@ Check whether the project already uses Mux workspace files:
 ls .mux/AGENTS.md .mux/init .mux/tool_post .mux/tool_env >/dev/null 2>&1 && echo "MUX_FOUND" || echo "MUX_NOT_FOUND"
 ```
 
-- If `MUX_FOUND` → Use `--with-mux` in bootstrap command.
-- If `MUX_NOT_FOUND` → Ask user if they want Mux compatibility. If yes, use `--with-mux`.
+- If `MUX_FOUND` → Use `--with-mux` in bootstrap command (Mux-only mode).
+- If `MUX_NOT_FOUND` → Ask user if they want Mux-only compatibility. If yes, use `--with-mux`.
 
 **If KANBAN_FOUND** → Use `--with-kanban-ui` flag. Tell the user:
 > Detected Beads Kanban UI. Configuring worktree management via API.
@@ -152,12 +152,9 @@ npx beads-orchestration@latest bootstrap \
 The bootstrap script will:
 1. Install beads CLI (via brew, npm, or go)
 2. Initialize `.beads/` directory
-3. Copy agent templates to `.claude/agents/`
-4. Copy hooks to `.claude/hooks/`
-5. Configure `.claude/settings.json`
-6. Create `CLAUDE.md` with orchestrator instructions
-7. Update `.gitignore`
-8. (Optional) Install Mux workspace files (`.mux/AGENTS.md`, `.mux/init`, `.mux/tool_post`, `.mux/tool_env`)
+3. Update `.gitignore`
+4. If `--with-mux`: install Mux-only files (`.mux/AGENTS.md`, `.mux/init`, `.mux/tool_post`, `.mux/tool_env`) and skip `.claude/*`
+5. If not `--with-mux`: install full Claude orchestration (`.claude/agents`, `.claude/hooks`, `.claude/settings.json`, `CLAUDE.md`)
 
 **Verify bootstrap completed successfully before proceeding.**
 
@@ -238,10 +235,11 @@ Discovery will:
 **Without `--with-kanban-ui`:**
 - Worktrees created via raw git commands
 
-**With `--with-mux`:**
+**With `--with-mux` (Mux-only mode):**
 - Installs `.mux/AGENTS.md` instruction layer
 - Installs `.mux/init`, `.mux/tool_post`, `.mux/tool_env`
 - Runs `.mux/init` once after bootstrap (best-effort)
+- Skips all `.claude/*` and `CLAUDE.md`
 
 ## Epic Workflow (Cross-Domain Features)
 

--- a/skills/subagents-discipline/SKILL.md
+++ b/skills/subagents-discipline/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: subagents-discipline
 description: Invoke at the start of any implementation task to enforce verification-first development
+advertise: true
 ---
 
 # Implementation Discipline

--- a/templates/mux/AGENTS.md
+++ b/templates/mux/AGENTS.md
@@ -1,0 +1,37 @@
+# AGENTS.md
+
+## Project
+
+[Project]
+
+## Mux + beads workflow
+
+This project uses `bd` (beads) for issue tracking and Mux for agent execution.
+
+### Required workflow
+
+1. `bd ready --json` to find unblocked work
+2. `bd update <id> --status in_progress --json` when you start
+3. Implement in the active workspace/worktree
+4. Validate changes
+5. `bd close <id> --reason "Completed" --json` when done
+
+### Mux hook notes
+
+- `.mux/init` primes beads context (`bd prime --stealth`) for new workspaces
+- `.mux/tool_post` runs `bd sync` after file edits
+- `.mux/tool_env` adds `~/bin` to `PATH` for shells that do not include it
+
+### Instruction layering
+
+Mux reads instruction layers from:
+- `~/.mux/AGENTS.md` (global)
+- `<workspace>/.mux/AGENTS.md` (workspace)
+
+Use `.mux/AGENTS.local.md` for personal local overrides (gitignored).
+
+### Rules
+
+- Use `bd` for all task tracking
+- Keep changes minimal and reviewable
+- Run relevant validation before reporting done

--- a/templates/mux/init
+++ b/templates/mux/init
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Mux workspace init hook
+# Runs once when a workspace is created.
+
+if command -v bd >/dev/null 2>&1; then
+  bd prime --stealth >/dev/null 2>&1 || true
+elif [ -x "$HOME/bin/bd" ]; then
+  "$HOME/bin/bd" prime --stealth >/dev/null 2>&1 || true
+fi

--- a/templates/mux/tool_env
+++ b/templates/mux/tool_env
@@ -1,0 +1,3 @@
+# Mux tool_env (sourced before bash tool calls)
+# Ensure bd installed in ~/bin is discoverable.
+export PATH="$HOME/bin:$PATH"

--- a/templates/mux/tool_post
+++ b/templates/mux/tool_post
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Mux tool_post hook
+# Keep bead metadata in sync after file edits.
+
+if [ "${MUX_TOOL:-}" = "file_edit_replace_string" ] || [ "${MUX_TOOL:-}" = "file_edit_insert" ]; then
+  if command -v bd >/dev/null 2>&1; then
+    bd sync >/dev/null 2>&1 || true
+  elif [ -x "$HOME/bin/bd" ]; then
+    "$HOME/bin/bd" sync >/dev/null 2>&1 || true
+  fi
+fi

--- a/templates/skills/react-best-practices/SKILL.md
+++ b/templates/skills/react-best-practices/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: react-best-practices
 description: React and Next.js performance optimization patterns. Use BEFORE implementing any React code to ensure best practices are followed.
+advertise: true
 ---
 
 # React Best Practices

--- a/templates/skills/subagents-discipline/SKILL.md
+++ b/templates/skills/subagents-discipline/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: subagents-discipline
 description: Core engineering principles for implementation tasks
+advertise: true
 ---
 
 # Implementation Principles


### PR DESCRIPTION
## Summary
- add optional `--with-mux` bootstrap mode to align with Mux workspace conventions
- install `.mux/AGENTS.md`, `.mux/init`, `.mux/tool_post`, `.mux/tool_env` from new templates
- run `.mux/init` once after bootstrap when enabled (best effort)
- update setup docs/skills/README for `--with-mux` flow
- add `advertise: true` to skill frontmatter where missing

## Details
- **bootstrap.py**
  - new `--with-mux` CLI flag
  - new `copy_mux_workspace_files(...)`
  - optional `.mux/init` execution via `run_mux_init_if_present(...)`
  - `.gitignore` setup supports `.mux/AGENTS.local.md` when mux mode is enabled
  - verification includes `.mux/*` files in mux mode
- **new templates** under `templates/mux/`
  - `AGENTS.md`
  - `init`
  - `tool_post`
  - `tool_env`
- **docs/skills**
  - update skill flow and examples to include mux detection + `--with-mux`
  - keep root `SKILL.md` in sync with packaged skill
  - README now documents optional Mux integration and installed `.mux` layout

## Validation
- `node --check scripts/cli.js`
- `node --check scripts/postinstall.js`
- `python3 -m py_compile bootstrap.py`
- `bash -n templates/mux/init templates/mux/tool_post`
- `bash tests/test-validate-epic-close.sh`
- `python3 bootstrap.py --help`
